### PR TITLE
utf8_normalize_spaces() 함수에서 CRLF 개행 문자 유지

### DIFF
--- a/common/functions.php
+++ b/common/functions.php
@@ -680,7 +680,7 @@ function utf8_mbencode($str): string
  */
 function utf8_normalize_spaces($str, bool $multiline = false): string
 {
-	return $multiline ? preg_replace('/((?!\x0A)[\pZ\pC])+/u', ' ', (string)$str) : preg_replace('/[\pZ\pC]+/u', ' ', (string)$str);
+	return $multiline ? preg_replace('/((?!\x0D|\x0A)[\pZ\pC])+/u', ' ', (string)$str) : preg_replace('/[\pZ\pC]+/u', ' ', (string)$str);
 }
 
 /**


### PR DESCRIPTION
개행 문자가 `\r\n`인 경우 `\r`이 공백 문자 ` (0x20)`로 변경 되는 문제를 수정했습니다.

`\r\n`값이 그대로 유지되도록 합니다.